### PR TITLE
Fixes for build in macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,9 @@ function available() {
    fi
 }
 
+command -v nproc &> /dev/null || function nproc() {
+    sysctl -n hw.physicalcpu
+}    
 
 available emcc
 available emconfigure

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ export ROOT=$PWD
 
 function available() {
    echo "Checking if $1 is available"
-   if ! [ -x $(command -v $1) ]; then
+   if ! [ -x "$(command -v $1)" ]; then
       echo "Error $1 is not installed" >&2
       exit 1
    fi


### PR DESCRIPTION
String quotation is needed to capture the case where the command is not available (at least in macOS).